### PR TITLE
fix: remove shortcut '\FA' from fontawesome.sty

### DIFF
--- a/fontawesome.sty
+++ b/fontawesome.sty
@@ -9,7 +9,7 @@
 \usepackage{fontspec}
 
 % Define shortcut to load the Font Awesome font.
-\newfontfamily{\FA}{FontAwesome}
+% \newfontfamily{\FA}{FontAwesome}
 % Generic command displaying an icon by its name.
 \newcommand*{\faicon}[1]{{
   \FA\csname faicon@#1\endcsname


### PR DESCRIPTION
It's not needed, once FontAwesome is already declared on awesome-cv.cls as '\FA' (line 164)